### PR TITLE
ci: transition to github app authentication for gitops

### DIFF
--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - develop
+      - staging
+      - main
     paths:
       - 'models/**'
       - 'scripts/**'
@@ -54,7 +56,8 @@ jobs:
           repository: hotosm/k8s-infra
           token: ${{ steps.generate-token.outputs.token }}
           path: k8s-infra
-          ref: develop
+          # Dynamically targets the matching environment branch in k8s-infra
+          ref: ${{ github.ref_name }}
 
       - name: Build, Push, and Update Models
         run: |
@@ -119,7 +122,8 @@ jobs:
           # Only commit if yq actually modified the values file
           if ! git diff-index --quiet HEAD; then
             git commit -m "chore(gitops): update model images to tag sha-${GITHUB_SHA::7} [skip ci]"
-            git push origin develop
+            # Dynamically push to the matching environment branch in k8s-infra
+            git push origin ${{ github.ref_name }}
           else
             echo "No changes to commit."
           fi

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -49,7 +49,8 @@ jobs:
           repository: hotosm/k8s-infra
           token: ${{ steps.generate-token.outputs.token }}
           path: k8s-infra
-          ref: feature/fair-models-deploy
+          # Now explicitly checking out the develop branch
+          ref: develop
 
       - name: Build, Push, and Update Models
         run: |
@@ -90,7 +91,8 @@ jobs:
           # Only commit if there are actual changes
           if ! git diff-index --quiet HEAD; then
             git commit -m "chore(gitops): update model images to tag sha-${GITHUB_SHA::7} [skip ci]"
-            git push origin feature/fair-models-deploy
+            # Now explicitly pushing directly to the develop branch
+            git push origin develop
           else
             echo "No changes to commit."
           fi

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -1,0 +1,92 @@
+name: Build Inference & Update K8s Infra
+
+on:
+  workflow_dispatch:
+    inputs:
+      model_name:
+        description: 'Model directory name (e.g., unet_segmentation)'
+        required: true
+        default: 'unet_segmentation'
+  push:
+    branches:
+      - develop
+    paths:
+      - 'models/**'
+
+jobs:
+  build-and-update-gitops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fair-models
+        uses: actions/checkout@v4
+
+      - name: Setup Python & uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Install Dependencies
+        run: |
+          uv sync --group dev
+          # Install yq for safely modifying the k8s-infra YAML
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
+
+      - name: Determine Model & Image Name
+        id: meta
+        run: |
+          # Use manual input if dispatched, otherwise default to unet_segmentation for this test
+          MODEL_NAME="${{ github.event.inputs.model_name || 'unet_segmentation' }}"
+          echo "MODEL_NAME=${MODEL_NAME}" >> $GITHUB_ENV
+          
+          # Use your existing STAC script to infer the image href
+          IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
+          echo "IMAGE_HREF=${IMAGE_HREF}" >> $GITHUB_ENV
+          
+          # Use the short commit SHA as a unique, immutable tag
+          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push Inference Image
+        run: |
+          docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
+          docker push "${IMAGE_HREF}:${IMAGE_TAG}"
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.INFRA_APP_ID }}
+          private-key: ${{ secrets.INFRA_APP_PRIVATE_KEY }}
+          owner: hotosm
+          repositories: k8s-infra
+
+      - name: Checkout k8s-infra
+        uses: actions/checkout@v4
+        with:
+          repository: hotosm/k8s-infra
+          token: ${{ steps.generate-token.outputs.token }}
+          path: k8s-infra
+          ref: feature/fair-models-deploy
+
+      - name: Update Helm Values
+        run: |
+          cd k8s-infra
+          VALUES_FILE="apps/fair-models/helm/values.yaml"
+          
+          # Dynamically update the image and tag using yq
+          yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
+          yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add $VALUES_FILE
+          git commit -m "chore(gitops): update ${MODEL_NAME} to tag ${IMAGE_TAG} [skip ci]"
+          git push origin feature/fair-models-deploy

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout fair-models
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # Required to run git diff against the previous commit
 
       - name: Setup Python & uv
         uses: astral-sh/setup-uv@v3
@@ -49,7 +51,6 @@ jobs:
           repository: hotosm/k8s-infra
           token: ${{ steps.generate-token.outputs.token }}
           path: k8s-infra
-          # Now explicitly checking out the develop branch
           ref: develop
 
       - name: Build, Push, and Update Models
@@ -58,27 +59,41 @@ jobs:
           IMAGE_TAG="sha-${GITHUB_SHA::7}"
           VALUES_FILE="k8s-infra/apps/fair-models/helm/values.yaml"
           
-          # Define all 4 models array
-          MODELS=("dinov3s_buildings" "resnet18_classification" "unet_segmentation" "yolo11n_detection")
+          # Determine which models to build
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Manual trigger detected. Building all models."
+            CHANGED_MODELS="dinov3s_buildings resnet18_classification unet_segmentation yolo11n_detection"
+          else
+            echo "Push detected. Finding modified models..."
+            # Extract unique model directory names that have changes
+            CHANGED_MODELS=$(git diff --name-only HEAD~1 HEAD | grep '^models/' | awk -F/ '{print $2}' | sort -u || true)
+          fi
           
-          for MODEL_NAME in "${MODELS[@]}"; do
-            echo "========================================="
-            echo "Processing ${MODEL_NAME}..."
-            echo "========================================="
-            
-            # 1. Infer Image HREF using your STAC script
-            IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
-            
-            # 2. Build the Docker Image
-            docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
-            
-            # 3. Push the Docker Image
-            docker push "${IMAGE_HREF}:${IMAGE_TAG}"
-            
-            # 4. Update the specific model's values in k8s-infra
-            yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
-            yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
-          done
+          if [ -z "$CHANGED_MODELS" ]; then
+            echo "No models were modified in this commit. Skipping image builds."
+          else
+            for MODEL_NAME in $CHANGED_MODELS; do
+              # Ensure the directory actually exists (in case a model was deleted)
+              if [ -d "models/${MODEL_NAME}" ]; then
+                echo "========================================="
+                echo "Processing ${MODEL_NAME}..."
+                echo "========================================="
+                
+                # 1. Infer Image HREF using your STAC script
+                IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
+                
+                # 2. Build the Docker Image
+                docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
+                
+                # 3. Push the Docker Image
+                docker push "${IMAGE_HREF}:${IMAGE_TAG}"
+                
+                # 4. Update the specific model's values in k8s-infra
+                yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
+                yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
+              fi
+            done
+          fi
 
       - name: Commit and Push to k8s-infra
         run: |
@@ -88,10 +103,9 @@ jobs:
           
           git add apps/fair-models/helm/values.yaml
           
-          # Only commit if there are actual changes
+          # Only commit if yq actually modified the values file
           if ! git diff-index --quiet HEAD; then
             git commit -m "chore(gitops): update model images to tag sha-${GITHUB_SHA::7} [skip ci]"
-            # Now explicitly pushing directly to the develop branch
             git push origin develop
           else
             echo "No changes to commit."

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -1,25 +1,44 @@
-name: Build Inference & Update K8s Infra
+name: Update K8s Infra
 
 on:
   workflow_dispatch:
-  push:
+    inputs:
+      model_name:
+        description: 'Specific model folder to update (e.g. dinov3s_buildings) or "all"'
+        type: string
+        required: false
+        default: 'all'
+  workflow_run:
+    workflows: ["Build Model Images"]
+    types:
+      - completed
     branches:
       - develop
       - staging
       - main
-    paths:
-      - 'models/**'
-      - 'scripts/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
 
 jobs:
-  build-and-update-gitops:
+  update-gitops:
     runs-on: ubuntu-latest
+    # Only run if triggered manually, OR if the CI build was successful
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Determine Target Branch and SHA
+        id: context
+        run: |
+          # Differentiate context between a manual run and a workflow_run trigger
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "TARGET_BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
+            echo "TARGET_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+          else
+            echo "TARGET_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "TARGET_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+          fi
+
       - name: Checkout fair-models
         uses: actions/checkout@v4
         with:
+          ref: ${{ env.TARGET_SHA }}
           fetch-depth: 2 # Required to run git diff against the previous commit
 
       - name: Setup Python & uv
@@ -33,13 +52,6 @@ jobs:
           # Install yq for safely modifying the k8s-infra YAML
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate GitHub App Token
         id: generate-token
@@ -56,28 +68,36 @@ jobs:
           repository: hotosm/k8s-infra
           token: ${{ steps.generate-token.outputs.token }}
           path: k8s-infra
-          # Dynamically targets the matching environment branch in k8s-infra
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.TARGET_BRANCH }}
 
-      - name: Build, Push, and Update Models
+      - name: Update Model Manifests in GitOps
         run: |
           # Use the short commit SHA as a unique, immutable tag
-          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          IMAGE_TAG="sha-${TARGET_SHA::7}"
           VALUES_FILE="k8s-infra/apps/fair-models/helm/values.yaml"
-          ALL_MODELS="dinov3s_buildings resnet18_classification unet_segmentation yolo11n_detection"
           
-          # Determine which models to build
+          # Dynamically find all directories inside the 'models/' folder
+          ALL_MODELS=$(find models -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | xargs)
+          
+          # Determine which models to update
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "Manual trigger detected. Building all models."
-            CHANGED_MODELS="$ALL_MODELS"
-          else
-            echo "Push detected. Checking changed files..."
+            INPUT_MODEL="${{ inputs.model_name }}"
             
-            # Check if core/global files changed (e.g., pyproject.toml, uv.lock, scripts/)
+            if [ -z "$INPUT_MODEL" ] || [ "$INPUT_MODEL" == "all" ]; then
+              echo "Manual trigger detected. Updating ALL models in k8s-infra."
+              CHANGED_MODELS="$ALL_MODELS"
+            else
+              echo "Manual trigger detected. Updating specific model: $INPUT_MODEL"
+              CHANGED_MODELS="$INPUT_MODEL"
+            fi
+          else
+            echo "CI Workflow completion detected. Checking changed files..."
+            
+            # Check if core/global files changed
             CORE_CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E '^(pyproject\.toml|uv\.lock|scripts/|\.github/)' || true)
             
             if [ -n "$CORE_CHANGED" ]; then
-              echo "Core/shared files changed ($CORE_CHANGED). Rebuilding all models as a safety measure."
+              echo "Core/shared files changed ($CORE_CHANGED). Updating all models as a safety measure."
               CHANGED_MODELS="$ALL_MODELS"
             else
               # Extract unique model directory names that have changes
@@ -86,27 +106,22 @@ jobs:
           fi
           
           if [ -z "$CHANGED_MODELS" ]; then
-            echo "No models were modified in this commit. Skipping image builds."
+            echo "No models were modified. Skipping GitOps update."
           else
             for MODEL_NAME in $CHANGED_MODELS; do
-              # Ensure the directory actually exists (in case a model was deleted)
               if [ -d "models/${MODEL_NAME}" ]; then
                 echo "========================================="
-                echo "Processing ${MODEL_NAME}..."
+                echo "Updating GitOps config for ${MODEL_NAME}..."
                 echo "========================================="
                 
                 # 1. Infer Image HREF using your STAC script
                 IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
                 
-                # 2. Build the Docker Image
-                docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
-                
-                # 3. Push the Docker Image
-                docker push "${IMAGE_HREF}:${IMAGE_TAG}"
-                
-                # 4. Update the specific model's values in k8s-infra
+                # 2. Update the specific model's values in k8s-infra
                 yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
                 yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
+              else
+                echo "Warning: Directory models/${MODEL_NAME} does not exist. Skipping."
               fi
             done
           fi
@@ -121,9 +136,8 @@ jobs:
           
           # Only commit if yq actually modified the values file
           if ! git diff-index --quiet HEAD; then
-            git commit -m "chore(gitops): update model images to tag sha-${GITHUB_SHA::7} [skip ci]"
-            # Dynamically push to the matching environment branch in k8s-infra
-            git push origin ${{ github.ref_name }}
+            git commit -m "chore(gitops): update model images to tag sha-${TARGET_SHA::7} [skip ci]"
+            git push origin ${{ env.TARGET_BRANCH }}
           else
             echo "No changes to commit."
           fi

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -7,6 +7,9 @@ on:
       - develop
     paths:
       - 'models/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build-and-update-gitops:
@@ -58,15 +61,25 @@ jobs:
           # Use the short commit SHA as a unique, immutable tag
           IMAGE_TAG="sha-${GITHUB_SHA::7}"
           VALUES_FILE="k8s-infra/apps/fair-models/helm/values.yaml"
+          ALL_MODELS="dinov3s_buildings resnet18_classification unet_segmentation yolo11n_detection"
           
           # Determine which models to build
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "Manual trigger detected. Building all models."
-            CHANGED_MODELS="dinov3s_buildings resnet18_classification unet_segmentation yolo11n_detection"
+            CHANGED_MODELS="$ALL_MODELS"
           else
-            echo "Push detected. Finding modified models..."
-            # Extract unique model directory names that have changes
-            CHANGED_MODELS=$(git diff --name-only HEAD~1 HEAD | grep '^models/' | awk -F/ '{print $2}' | sort -u || true)
+            echo "Push detected. Checking changed files..."
+            
+            # Check if core/global files changed (e.g., pyproject.toml, uv.lock, scripts/)
+            CORE_CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E '^(pyproject\.toml|uv\.lock|scripts/|\.github/)' || true)
+            
+            if [ -n "$CORE_CHANGED" ]; then
+              echo "Core/shared files changed ($CORE_CHANGED). Rebuilding all models as a safety measure."
+              CHANGED_MODELS="$ALL_MODELS"
+            else
+              # Extract unique model directory names that have changes
+              CHANGED_MODELS=$(git diff --name-only HEAD~1 HEAD | grep '^models/' | awk -F/ '{print $2}' | sort -u || true)
+            fi
           fi
           
           if [ -z "$CHANGED_MODELS" ]; then

--- a/.github/workflows/deploy-knative.yml
+++ b/.github/workflows/deploy-knative.yml
@@ -2,11 +2,6 @@ name: Build Inference & Update K8s Infra
 
 on:
   workflow_dispatch:
-    inputs:
-      model_name:
-        description: 'Model directory name (e.g., unet_segmentation)'
-        required: true
-        default: 'unet_segmentation'
   push:
     branches:
       - develop
@@ -32,32 +27,12 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
 
-      - name: Determine Model & Image Name
-        id: meta
-        run: |
-          # Use manual input if dispatched, otherwise default to unet_segmentation for this test
-          MODEL_NAME="${{ github.event.inputs.model_name || 'unet_segmentation' }}"
-          echo "MODEL_NAME=${MODEL_NAME}" >> $GITHUB_ENV
-          
-          # Use your existing STAC script to infer the image href
-          IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
-          echo "IMAGE_HREF=${IMAGE_HREF}" >> $GITHUB_ENV
-          
-          # Use the short commit SHA as a unique, immutable tag
-          IMAGE_TAG="sha-${GITHUB_SHA::7}"
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Inference Image
-        run: |
-          docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
-          docker push "${IMAGE_HREF}:${IMAGE_TAG}"
 
       - name: Generate GitHub App Token
         id: generate-token
@@ -76,17 +51,46 @@ jobs:
           path: k8s-infra
           ref: feature/fair-models-deploy
 
-      - name: Update Helm Values
+      - name: Build, Push, and Update Models
+        run: |
+          # Use the short commit SHA as a unique, immutable tag
+          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          VALUES_FILE="k8s-infra/apps/fair-models/helm/values.yaml"
+          
+          # Define all 4 models array
+          MODELS=("dinov3s_buildings" "resnet18_classification" "unet_segmentation" "yolo11n_detection")
+          
+          for MODEL_NAME in "${MODELS[@]}"; do
+            echo "========================================="
+            echo "Processing ${MODEL_NAME}..."
+            echo "========================================="
+            
+            # 1. Infer Image HREF using your STAC script
+            IMAGE_HREF=$(uv run python scripts/stac_asset.py "models/${MODEL_NAME}/stac-item.json" mlm:inference)
+            
+            # 2. Build the Docker Image
+            docker build -f "models/${MODEL_NAME}/Dockerfile" --target inference -t "${IMAGE_HREF}:${IMAGE_TAG}" .
+            
+            # 3. Push the Docker Image
+            docker push "${IMAGE_HREF}:${IMAGE_TAG}"
+            
+            # 4. Update the specific model's values in k8s-infra
+            yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
+            yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
+          done
+
+      - name: Commit and Push to k8s-infra
         run: |
           cd k8s-infra
-          VALUES_FILE="apps/fair-models/helm/values.yaml"
-          
-          # Dynamically update the image and tag using yq
-          yq -i ".models.${MODEL_NAME}.image = \"${IMAGE_HREF}\"" $VALUES_FILE
-          yq -i ".models.${MODEL_NAME}.tag = \"${IMAGE_TAG}\"" $VALUES_FILE
-          
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add $VALUES_FILE
-          git commit -m "chore(gitops): update ${MODEL_NAME} to tag ${IMAGE_TAG} [skip ci]"
-          git push origin feature/fair-models-deploy
+          
+          git add apps/fair-models/helm/values.yaml
+          
+          # Only commit if there are actual changes
+          if ! git diff-index --quiet HEAD; then
+            git commit -m "chore(gitops): update model images to tag sha-${GITHUB_SHA::7} [skip ci]"
+            git push origin feature/fair-models-deploy
+          else
+            echo "No changes to commit."
+          fi


### PR DESCRIPTION
### Overview
This PR refactors our Knative deployment workflow to act strictly as a Continuous Deployment (CD) pipeline. Following some great team feedback, I've chained this workflow to run *after* the `Build Model Images` pipeline finishes. This stops us from duplicating Docker builds, saving us CI minutes and preventing potential race conditions.

It still handles the GitOps side of things by scanning for changes and securely updating the `values.yaml` in our `k8s-infra` repository with the newly built immutable image tags.

### Changes Made
* **Separated CI and CD:** Switched the trigger to `workflow_run` so it executes automatically upon the successful completion of the `Build Model Images` pipeline. Removed all `docker build`, `push`, and `login` steps since the upstream workflow already handles the heavy lifting.
* **Dynamic Model Discovery:** Replaced the hardcoded list of models with a dynamic `find` command. If a data scientist adds a new model directory under `models/`, the pipeline will detect and process it automatically without requiring maintenance.
* **Targeted Manual Runs:** Added a `model_name` input to the `workflow_dispatch` trigger. When testing manually, you can now target a specific model (e.g., `unet_segmentation`) instead of forcing the script to process the entire catalog. Defaults to `all`.
* **Multi-Environment Ready:** Dynamically targets the correct environment branch (`develop`, `staging`, `main`) in the `k8s-infra` repository based on the triggering branch.
* **Secure Cross-Repo Auth:** Integrates the `actions/create-github-app-token` step to generate a short-lived token using our dedicated internal GitHub App.

### Testing Notes
* **DO NOT MERGE YET:** Waiting for DK to finish provisioning the GitHub App and adding the `INFRA_APP_ID` / `INFRA_APP_PRIVATE_KEY` secrets to this repo.
* Can be tested manually via `workflow_dispatch` in the Actions tab once the credentials are live. The manual trigger will pop up a text box asking which model you want to update.
* Standard automated runs will now trigger seamlessly behind the scenes once the upstream build workflow succeeds.